### PR TITLE
Added secondary sources to the codebuild module

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_codebuild_project](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -171,6 +186,19 @@ No requirements.
 | cloudwatch\_logs\_group\_name | The group name of the logs in CloudWatch Logs. | `string` | `null` | no |
 | cloudwatch\_logs\_status | Current status of logs in CloudWatch Logs for a build project. Valid values: `ENABLED`, `DISABLED.` | `string` | `"ENABLED"` | no |
 | cloudwatch\_logs\_stream\_name | The stream name of the logs in CloudWatch Logs. | `string` | `null` | no |
+| codebuild\_secondary\_source | Information about the project's secondary source code. | `any` | `{}` | no |
+| codebuild\_secondary\_source\_auth | Information about the authorization settings for AWS CodeBuild to access the source code to be built. | `map` | `{}` | no |
+| codebuild\_secondary\_source\_auth\_resource | The resource value that applies to the specified authorization type. | `string` | `null` | no |
+| codebuild\_secondary\_source\_auth\_type | The authorization type to use. The only valid value is OAUTH | `string` | `"OAUTH"` | no |
+| codebuild\_secondary\_source\_buildspec | The build spec declaration to use for this build project's related builds. Optional | `string` | `null` | no |
+| codebuild\_secondary\_source\_git\_clone\_depth | Information about the Git submodules configuration for an AWS CodeBuild build project. Git submodules config blocks are documented below. This option is only valid when the type is `CODECOMMIT`. | `number` | `0` | no |
+| codebuild\_secondary\_source\_git\_submodules\_config | Information about the Git submodules configuration for an AWS CodeBuild build project. Git submodules config blocks are documented below. This option is only valid when the type is `CODECOMMIT`. | `map` | `{}` | no |
+| codebuild\_secondary\_source\_git\_submodules\_config\_fetch\_submodules | If set to true, fetches Git submodules for the AWS CodeBuild build project. | `bool` | `true` | no |
+| codebuild\_secondary\_source\_identifier | The name of a folder named that the source will be checked out into inside the AWS CodeBuild source directory | `string` | `null` | no |
+| codebuild\_secondary\_source\_insecure\_ssl | Ignore SSL warnings when connecting to source control. | `bool` | `false` | no |
+| codebuild\_secondary\_source\_location | The location of the source code from git or s3. | `string` | `null` | no |
+| codebuild\_secondary\_source\_report\_build\_status | Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the type is `BITBUCKET` or `GITHUB`. | `bool` | `false` | no |
+| codebuild\_secondary\_source\_type | The type of repository that contains the secondary source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET`, `S3` or `NO_SOURCE`. | `string` | `"CODEPIPELINE"` | no |
 | codebuild\_source | Information about the project's input source code. | `any` | `{}` | no |
 | codebuild\_source\_auth | Information about the authorization settings for AWS CodeBuild to access the source code to be built. | `map` | `{}` | no |
 | codebuild\_source\_auth\_resource | The resource value that applies to the specified authorization type. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,37 @@ resource "aws_codebuild_project" "cb_project" {
     }
   }
 
+  # Secondary Sources
+  dynamic "secondary_sources" {
+    for_each = local.secondary_source
+    content {
+      type                = lookup(secondary_sources.value, "type")
+      buildspec           = lookup(secondary_sources.value, "buildspec")
+      git_clone_depth     = lookup(secondary_sources.value, "git_clone_depth")
+      insecure_ssl        = lookup(secondary_sources.value, "insecure_ssl")
+      location            = lookup(secondary_sources.value, "location")
+      report_build_status = lookup(secondary_sources.value, "report_build_status")
+      source_identifier   = lookup(secondary_sources.value, "source_identifier")
+
+      # Auth
+      dynamic "auth" {
+        for_each = length(lookup(secondary_sources.value, "auth")) == 0 ? [] : [lookup(secondary_sources.value, "auth")]
+        content {
+          type     = auth.value.type
+          resource = auth.value.resource
+        }
+      }
+
+      # Git Submodules Config
+      dynamic "git_submodules_config" {
+        for_each = length(lookup(secondary_sources.value, "git_submodules_config")) == 0 ? [] : [lookup(secondary_sources.value, "git_submodules_config")]
+        content {
+          fetch_submodules = git_submodules_config.value.fetch_submodules
+        }
+      }
+    }
+  }
+
   # VPC Config
   dynamic "vpc_config" {
     for_each = lookup(local.vpc_config, "vpc_id") == null ? [] : [local.vpc_config]
@@ -219,6 +250,22 @@ locals {
       report_build_status   = lookup(var.codebuild_source, "report_build_status", null) == null ? var.codebuild_source_report_build_status : lookup(var.codebuild_source, "report_build_status")
       auth                  = lookup(var.codebuild_source, "auth", null) == null ? var.codebuild_source_auth : lookup(var.codebuild_source, "auth")
       git_submodules_config = lookup(var.codebuild_source, "git_submodules_config", null) == null ? var.codebuild_source_git_submodules_config : lookup(var.codebuild_source, "git_submodules_config")
+    }
+  ]
+
+  # Secondary Sources
+  # If no block is provided build one using defaults
+  secondary_source = [
+    {
+      type                  = lookup(var.codebuild_secondary_source, "type", null) == null ? var.codebuild_secondary_source_type : lookup(var.codebuild_secondary_source, "type")
+      buildspec             = lookup(var.codebuild_secondary_source, "buildspec", null) == null ? var.codebuild_secondary_source_buildspec : lookup(var.codebuild_secondary_source, "buildspec")
+      git_clone_depth       = lookup(var.codebuild_secondary_source, "git_clone_depth", null) == null ? var.codebuild_secondary_source_git_clone_depth : lookup(var.codebuild_secondary_source, "git_clone_depth")
+      insecure_ssl          = lookup(var.codebuild_secondary_source, "insecure_ssl", null) == null ? var.codebuild_secondary_source_insecure_ssl : lookup(var.codebuild_secondary_source, "insecure_ssl")
+      location              = lookup(var.codebuild_secondary_source, "location", null) == null ? var.codebuild_secondary_source_location : lookup(var.codebuild_secondary_source, "location")
+      report_build_status   = lookup(var.codebuild_secondary_source, "report_build_status", null) == null ? var.codebuild_secondary_source_report_build_status : lookup(var.codebuild_secondary_source, "report_build_status")
+      source_identifier     = lookup(var.codebuild_secondary_source, "source_identifier", null) == null ? var.codebuild_secondary_source_identifier : lookup(var.codebuild_secondary_source, "source_identifier")
+      auth                  = lookup(var.codebuild_secondary_source, "auth", null) == null ? var.codebuild_secondary_source_auth : lookup(var.codebuild_secondary_source, "auth")
+      git_submodules_config = lookup(var.codebuild_secondary_source, "git_submodules_config", null) == null ? var.codebuild_secondary_source_git_submodules_config : lookup(var.codebuild_secondary_source, "git_submodules_config")
     }
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -303,6 +303,85 @@ variable "codebuild_source_git_submodules_config_fetch_submodules" {
   default     = true
 }
 
+# Secondary Source
+variable "codebuild_secondary_source" {
+  description = "Information about the project's secondary source code."
+  type        = any
+  default     = {}
+}
+
+variable "codebuild_secondary_source_type" {
+  description = "The type of repository that contains the secondary source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET`, `S3` or `NO_SOURCE`."
+  type        = string
+  default     = "CODEPIPELINE"
+}
+
+variable "codebuild_secondary_source_buildspec" {
+  description = "The build spec declaration to use for this build project's related builds. Optional"
+  type        = string
+  default     = null
+}
+
+variable "codebuild_secondary_source_git_clone_depth" {
+  description = "Information about the Git submodules configuration for an AWS CodeBuild build project. Git submodules config blocks are documented below. This option is only valid when the type is `CODECOMMIT`."
+  type        = number
+  default     = 0
+}
+
+variable "codebuild_secondary_source_insecure_ssl" {
+  description = "Ignore SSL warnings when connecting to source control."
+  type        = bool
+  default     = false
+}
+
+variable "codebuild_secondary_source_location" {
+  description = "The location of the source code from git or s3."
+  type        = string
+  default     = null
+}
+
+variable "codebuild_secondary_source_report_build_status" {
+  description = "Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the type is `BITBUCKET` or `GITHUB`."
+  type        = bool
+  default     = false
+}
+
+variable "codebuild_secondary_source_auth" {
+  description = "Information about the authorization settings for AWS CodeBuild to access the source code to be built."
+  type        = map
+  default     = {}
+}
+
+variable "codebuild_secondary_source_auth_type" {
+  description = "The authorization type to use. The only valid value is OAUTH"
+  type        = string
+  default     = "OAUTH"
+}
+
+variable "codebuild_secondary_source_auth_resource" {
+  description = "The resource value that applies to the specified authorization type."
+  type        = string
+  default     = null
+}
+
+variable "codebuild_secondary_source_git_submodules_config" {
+  description = "Information about the Git submodules configuration for an AWS CodeBuild build project. Git submodules config blocks are documented below. This option is only valid when the type is `CODECOMMIT`."
+  type        = map
+  default     = {}
+}
+
+variable "codebuild_secondary_source_identifier" {
+  description = "The name of a folder named that the source will be checked out into inside the AWS CodeBuild source directory"
+  type        = string
+  default     = null
+}
+
+variable "codebuild_secondary_source_git_submodules_config_fetch_submodules" {
+  description = "If set to true, fetches Git submodules for the AWS CodeBuild build project."
+  type        = bool
+  default     = true
+}
+
 # VPC Config
 variable "vpc_config" {
   description = "Configuration for the builds to run inside a VPC."


### PR DESCRIPTION
I needed to checkout a repository as a dependency to do a full end to end build

Added support for the secondary_sources construct